### PR TITLE
Tf edit category

### DIFF
--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -64,21 +64,28 @@ namespace TabloidMVC.Controllers
         // GET: CategoryController/Edit/5
         public ActionResult Edit(int id)
         {
-            return View();
+            Category category = _categoryRepositroy.GetCategoryById(id);
+            if (category == null)
+            {
+                return NotFound();
+            }
+            return View(category);
         }
 
         // POST: CategoryController/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Edit(int id, IFormCollection collection)
+        public ActionResult Edit(int id, Category category)
         {
             try
             {
-                return RedirectToAction(nameof(Index));
+                _categoryRepositroy.UpdateCategory(category);
+
+                return RedirectToAction("Index");
             }
             catch
             {
-                return View();
+                return View(category);
             }
         }
 

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -64,6 +64,7 @@ namespace TabloidMVC.Controllers
         // GET: CategoryController/Edit/5
         public ActionResult Edit(int id)
         {
+            //grabs the category clicked with by it's id that is stored in the database
             Category category = _categoryRepositroy.GetCategoryById(id);
             if (category == null)
             {
@@ -79,12 +80,15 @@ namespace TabloidMVC.Controllers
         {
             try
             {
+                // runs the method UpdateCategory saving the changes made within the edit functionality in the browser 
                 _categoryRepositroy.UpdateCategory(category);
 
+                // return will take you back to the index view listing all of the categories with any edits made
                 return RedirectToAction("Index");
             }
             catch
             {
+                //this will keep you in the same view of editing a category and keep you there signaling there is most likely an issue with the SQL Query
                 return View(category);
             }
         }

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -15,41 +15,41 @@ namespace TabloidMVC.Controllers
     {
         private readonly IPostRepository _postRepository;
         private readonly ICategoryRepository _categoryRepository;
-								private readonly IUserProfileRepository _userRepository;
+        private readonly IUserProfileRepository _userRepository;
 
         public PostController(
-												IPostRepository postRepository, 
-												ICategoryRepository categoryRepository, 
-												IUserProfileRepository userProfileRepository)
+                                                IPostRepository postRepository,
+                                                ICategoryRepository categoryRepository,
+                                                IUserProfileRepository userProfileRepository)
         {
             _postRepository = postRepository;
             _categoryRepository = categoryRepository;
-												_userRepository = userProfileRepository;
+            _userRepository = userProfileRepository;
 
         }
 
         public IActionResult Index(int UserId)
         {
-												int activeUser = GetCurrentUserProfileId();
-												if (activeUser == UserId)
-												{
-																var posts = _postRepository.GetPublishedByUser(activeUser);
-																return View(posts);
-												}
-												else
-												{
-																var posts = _postRepository.GetAllPublishedPosts();
-																return View(posts);
-												}
+            int activeUser = GetCurrentUserProfileId();
+            if (activeUser == UserId)
+            {
+                var posts = _postRepository.GetPublishedByUser(activeUser);
+                return View(posts);
+            }
+            else
+            {
+                var posts = _postRepository.GetAllPublishedPosts();
+                return View(posts);
+            }
         }
 
-								public IActionResult Myposts(int UserId)
-								{
-												int activeUser = GetCurrentUserProfileId();
-												var posts = _postRepository.GetPublishedByUser(activeUser);
-												return View(posts);
+        public IActionResult Myposts(int UserId)
+        {
+            int activeUser = GetCurrentUserProfileId();
+            var posts = _postRepository.GetPublishedByUser(activeUser);
+            return View(posts);
 
-								}
+        }
 
         public IActionResult Details(int id)
         {

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -106,5 +106,27 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+
+        public void UpdateCategory(Category category)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                            UPDATE Category
+                            SET 
+                                [Name] = @name 
+                            WHERE Id = @id";
+
+                    cmd.Parameters.AddWithValue("@name", category.Name);
+                    cmd.Parameters.AddWithValue("@id", category.Id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
     }
 }

--- a/TabloidMVC/Repositories/ICategoryRepository.cs
+++ b/TabloidMVC/Repositories/ICategoryRepository.cs
@@ -13,5 +13,6 @@ namespace TabloidMVC.Repositories
         //interface to delete a category from the categories ID
         void Delete(int categoryId);
         Category GetCategoryById(int id);
+        void UpdateCategory(Category category);
     }
 }

--- a/TabloidMVC/Views/Category/Edit.cshtml
+++ b/TabloidMVC/Views/Category/Edit.cshtml
@@ -1,0 +1,33 @@
+﻿@model TabloidMVC.Models.Category
+
+@{
+    ViewData["Title"] = "Edit";
+}
+
+<h1>Edit</h1>
+
+<h4>Category</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Save" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}


### PR DESCRIPTION
# User can Edit Categories
​
Given the user is logged in they can go to the "categories" tab on the nav bar which will take them to a listed view of all categories. As a user I would like to be able to edit a categories name if needed. By clicking the edit function of a category you will be taken to an edit view allowing you to change the name of the category and save that name taking you back to the listed view of all available categories.
​
## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Pull down and checkout my branch tf-edit-category
2. Start the application in VSCode
3. When the application loads ensure you are logged in, if not use the provided login information to login and go through the navigation menu to access "categories" **Login credentials: Admin@example.com**
4. Click on the edit button of a category that you would like to edit
5. From the new view to edit a category, change the name of the category and click "save"
6. Once you have clicked "save" you will be taken back to view of all categories and find the one you edited to ensure the changes were saved confirming this feature works

​
# Checklist:
​
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings